### PR TITLE
fix: llvmのCREL使用を止める

### DIFF
--- a/build/linux-arm/Makefile
+++ b/build/linux-arm/Makefile
@@ -41,7 +41,8 @@ patch: common-patch
 	patch -p1 < $(PATCH_DIR)/4k_linux.patch && \
 	patch -p1 < $(PATCH_DIR)/disable_use_hermetic_xcode_on_linux.patch && \
 	patch -p1 < $(PATCH_DIR)/linux_clang_optional.patch && \
-	patch -p1 < $(PATCH_DIR)/linux_fix_enable_safe_libstdcxx.patch
+	patch -p1 < $(PATCH_DIR)/linux_fix_enable_safe_libstdcxx.patch && \
+	patch -p1 < $(PATCH_DIR)/linux_remove_crel.patch
 
 .PHONY: build
 build: download patch

--- a/build/linux-arm64/Makefile
+++ b/build/linux-arm64/Makefile
@@ -41,7 +41,8 @@ patch: common-patch
 	patch -p1 < $(PATCH_DIR)/4k_linux.patch && \
 	patch -p1 < $(PATCH_DIR)/disable_use_hermetic_xcode_on_linux.patch && \
 	patch -p1 < $(PATCH_DIR)/linux_clang_optional.patch && \
-	patch -p1 < $(PATCH_DIR)/linux_fix_enable_safe_libstdcxx.patch
+	patch -p1 < $(PATCH_DIR)/linux_fix_enable_safe_libstdcxx.patch && \
+	patch -p1 < $(PATCH_DIR)/linux_remove_crel.patch
 
 .PHONY: build
 build: download patch

--- a/build/linux-x64/Makefile
+++ b/build/linux-x64/Makefile
@@ -41,7 +41,8 @@ patch: common-patch
 	patch -p1 < $(PATCH_DIR)/4k_linux.patch && \
 	patch -p1 < $(PATCH_DIR)/disable_use_hermetic_xcode_on_linux.patch && \
 	patch -p1 < $(PATCH_DIR)/linux_clang_optional.patch && \
-	patch -p1 < $(PATCH_DIR)/linux_fix_enable_safe_libstdcxx.patch
+	patch -p1 < $(PATCH_DIR)/linux_fix_enable_safe_libstdcxx.patch && \
+	patch -p1 < $(PATCH_DIR)/linux_remove_crel.patch
 
 .PHONY: build
 build: download patch

--- a/patch/linux_remove_crel.patch
+++ b/patch/linux_remove_crel.patch
@@ -1,0 +1,18 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index fca6c9295..bc3a0337d 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -617,13 +617,6 @@ config("compiler") {
+       cflags += [ "-ffp-contract=off" ]
+     }
+ 
+-    # Enable ELF CREL (see crbug.com/357878242) for all platforms that use ELF
+-    # (excluding toolchains that use an older version of LLVM).
+-    if (is_linux && use_lld && !llvm_android_mainline &&
+-        default_toolchain != "//build/toolchain/cros:target") {
+-      cflags += [ "-Wa,--crel,--allow-experimental-crel" ]
+-    }
+-
+     # TODO(crbug.com/413427035): Remove once
+     # https://github.com/llvm/llvm-project/pull/136867/ is landed.
+     if (!is_win && !llvm_android_mainline &&


### PR DESCRIPTION
m133から有効になっている
m137からはuse_lldオプションで制御出来るようなので試す

refs #40